### PR TITLE
Policy refactor

### DIFF
--- a/include/seeds.policy.hpp
+++ b/include/seeds.policy.hpp
@@ -1,5 +1,6 @@
 #include <eosio/eosio.hpp>
 #include <contracts.hpp>
+#include <tables.hpp>
 
 using namespace eosio;
 using std::string;
@@ -8,7 +9,9 @@ CONTRACT policy : public contract {
   public:
     using contract::contract;
     policy(name receiver, name code, datastream<const char*> ds)
-      : contract(receiver, code, ds)
+      : contract(receiver, code, ds),
+        devicepolicy(receiver, receiver.value),
+        users(contracts::accounts, contracts::accounts.value)
       {}
 
     ACTION reset();
@@ -16,6 +19,7 @@ CONTRACT policy : public contract {
     ACTION create(name account, string backend_user_id, string device_id, string signature, string policy);
 
     ACTION update(name account, string backend_user_id, string device_id, string signature, string policy);
+
   private:
     TABLE policy_table {
       name account;
@@ -34,8 +38,36 @@ CONTRACT policy : public contract {
       uint64_t primary_key()const { return account.value; }
     };
 
+    TABLE device_policy_table {
+      uint64_t id;
+      name account;
+      string backend_user_id;
+      string device_id;
+      string signature;
+      string policy;
+      uint64_t primary_key()const { return id; }
+      uint64_t by_account()const { return account.value; }
+    };
+
+    // needed for reset
+    typedef eosio::multi_index<"users"_n, tables::user_table,
+      indexed_by<"byreputation"_n,
+      const_mem_fun<tables::user_table, uint64_t, &tables::user_table::by_reputation>>
+    > user_tables;
+
+
     typedef eosio::multi_index<"policies"_n, policy_table> policy_tables;
+
     typedef eosio::multi_index<"policiesnew"_n, policy_table_new> policy_tables_new;
+
+    typedef eosio::multi_index<"devicepolicy"_n, device_policy_table,
+      indexed_by<"byaccount"_n,
+      const_mem_fun<device_policy_table, uint64_t, &device_policy_table::by_account>>
+    > device_policy_tables;
+
+    user_tables users;
+    device_policy_tables devicepolicy;
+
 
 };
 

--- a/include/seeds.policy.hpp
+++ b/include/seeds.policy.hpp
@@ -1,6 +1,5 @@
 #include <eosio/eosio.hpp>
 #include <contracts.hpp>
-#include <tables.hpp>
 
 using namespace eosio;
 using std::string;
@@ -10,33 +9,18 @@ CONTRACT policy : public contract {
     using contract::contract;
     policy(name receiver, name code, datastream<const char*> ds)
       : contract(receiver, code, ds),
-        devicepolicy(receiver, receiver.value),
-        users(contracts::accounts, contracts::accounts.value)
+        devicepolicy(receiver, receiver.value)
       {}
 
     ACTION reset();
 
     ACTION create(name account, string backend_user_id, string device_id, string signature, string policy);
 
-    ACTION update(name account, string backend_user_id, string device_id, string signature, string policy);
+    ACTION update(uint64_t id, name account, string backend_user_id, string device_id, string signature, string policy);
+
+    ACTION remove(uint64_t id);
 
   private:
-    TABLE policy_table {
-      name account;
-      string uuid;
-      string signature;
-      string policy;
-      uint64_t primary_key()const { return account.value; }
-    };
-
-    TABLE policy_table_new {
-      name account;
-      string backend_user_id;
-      string device_id;
-      string signature;
-      string policy;
-      uint64_t primary_key()const { return account.value; }
-    };
 
     TABLE device_policy_table {
       uint64_t id;
@@ -49,26 +33,14 @@ CONTRACT policy : public contract {
       uint64_t by_account()const { return account.value; }
     };
 
-    // needed for reset
-    typedef eosio::multi_index<"users"_n, tables::user_table,
-      indexed_by<"byreputation"_n,
-      const_mem_fun<tables::user_table, uint64_t, &tables::user_table::by_reputation>>
-    > user_tables;
-
-
-    typedef eosio::multi_index<"policies"_n, policy_table> policy_tables;
-
-    typedef eosio::multi_index<"policiesnew"_n, policy_table_new> policy_tables_new;
-
     typedef eosio::multi_index<"devicepolicy"_n, device_policy_table,
       indexed_by<"byaccount"_n,
       const_mem_fun<device_policy_table, uint64_t, &device_policy_table::by_account>>
     > device_policy_tables;
 
-    user_tables users;
     device_policy_tables devicepolicy;
 
 
 };
 
-EOSIO_DISPATCH(policy, (create)(update)(reset));
+EOSIO_DISPATCH(policy, (create)(update)(reset)(remove));

--- a/include/tables.hpp
+++ b/include/tables.hpp
@@ -1,4 +1,6 @@
 #include <eosio/eosio.hpp>
+#include <eosio/asset.hpp>
+
 
 using eosio::name;
 using eosio::asset;

--- a/src/seeds.policy.cpp
+++ b/src/seeds.policy.cpp
@@ -3,15 +3,26 @@
 void policy::reset() {
   require_auth(_self);
 
-  /*
-  policy_tables_new policies(_self, name("seedsuser444").value);
+  auto uitr = users.begin();
+  while (uitr != users.end()) {
 
-  auto pitr = policies.begin();
+    // delete new policies
+    policy_tables_new policies(_self, uitr->account.value);
+    auto pitr = policies.begin();
+    while (pitr != policies.end()) {
+      pitr = policies.erase(pitr);
+    }
 
-  while (pitr != policies.end()) {
-    pitr = policies.erase(pitr);
+    // delete old policies
+    policy_tables oldpol(_self, uitr->account.value);
+    auto opitr = oldpol.begin();
+    while (opitr != oldpol.end()) {
+      opitr = oldpol.erase(opitr);
+    }
+
+    uitr++;
   }
-  */
+
 }
 
 void policy::create(name account, string backend_user_id, string device_id, string signature, string policy) {

--- a/test/policy.test.js
+++ b/test/policy.test.js
@@ -1,7 +1,7 @@
 const { describe } = require('riteway')
 const { eos, names, isLocal } = require('../scripts/helper')
 
-const { policy, firstuser } = names
+const { policy, firstuser, seconduser } = names
 
 describe('policy', async assert => {
 
@@ -32,6 +32,7 @@ describe('policy', async assert => {
   policyField = 'updated-policy-string'
 
   await contract.update(
+    0,
     accountField,
     uuidField,
     deviceField,
@@ -42,16 +43,76 @@ describe('policy', async assert => {
 
   const { rows } = await eos.getTableRows({
     code: policy,
-    scope: firstuser,
-    table: 'policiesnew',
+    scope: policy,
+    table: 'devicepolicy',
     json: true
   })
+
+  let secondDeviceUUID = '777-999'
+  let secondDeviceField = '13:33'
+
+  await contract.create(
+    accountField,
+    secondDeviceUUID,
+    secondDeviceField,
+    signatureField,
+    policyField,
+    { authorization: `${firstuser}@active` }
+  )
+
+  const afterAddSecondDevice = await eos.getTableRows({
+    code: policy,
+    scope: policy,
+    table: 'devicepolicy',
+    json: true
+  })
+
+  await contract.remove(
+    1,
+    { authorization: `${firstuser}@active` }
+  )
+
+  const afterRemove = await eos.getTableRows({
+    code: policy,
+    scope: policy,
+    table: 'devicepolicy',
+    json: true
+  })
+
+  var onlyAuthorizedCanRemove = true
+  try {
+    await contract.remove(
+      0,
+      { authorization: `${seconduser}@active` }
+    )
+    onlyAuthorizedCanRemove = false
   
+  } catch (err) {
+    console.log(err)
+
+  }
+
+
+  assert({
+    given: 'added second policy',
+    should: 'have 2 policies',
+    actual: afterAddSecondDevice.rows[1],
+    expected: {
+      id: 1,
+      account: accountField,
+      backend_user_id: secondDeviceUUID,
+      device_id: secondDeviceField,
+      signature: signatureField,
+      policy: policyField
+    }
+  })
+
   assert({
     given: 'created & updated policy',
     should: 'show created row in table',
     actual: rows,
     expected: [{
+      id: 0,
       account: accountField,
       backend_user_id: uuidField,
       device_id: deviceField,
@@ -59,4 +120,12 @@ describe('policy', async assert => {
       policy: policyField
     }]
   })
+
+  assert({
+    given: 'deleted policy',
+    should: 'row deleted',
+    actual: afterRemove.rows.length,
+    expected: 1
+  })
+
 })


### PR DESCRIPTION
As per Antonio, requirement is that we have > 1 policy per user - one for each device

Also each account may be on multiple user devices.

## Solution
- Changed policy table to be not scoped (as that was useless)
- renamed for convenience
- Added auto id to table
- Added account as secondary index
- Added remove - we will need this eventually
- Updated unit tests