### PR TITLE
disable funding campaigns

### DIFF
--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -128,6 +128,8 @@ CONTRACT proposals : public contract {
       ACTION fixcycstat(uint64_t delete_round);
       ACTION testisbanned(name account);
 
+      ACTION migcampaign ( uint64_t start, uint64_t chunksize );
+
   private:
       symbol seeds_symbol = symbol("SEEDS", 4);
       name trust = "trust"_n;
@@ -143,6 +145,7 @@ CONTRACT proposals : public contract {
       name status_evaluate = name("evaluate");
       name status_passed = name("passed");
       name status_rejected = name("rejected");
+      name status_inactive = name("inactive");
 
       // stages
       name stage_staged = name("staged"); // 1 staged: can be cancelled, edited
@@ -476,7 +479,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         (testperiod)(testevalprop)
         (cleanmig)(testpropquor)
         (reevalprop)
-        (testalliance)(migalliances)
+        (testalliance)(migalliances)(migcampaign)
         (fixdesc)(applyfixprop)(backfixprop)
         (revertvote)(mimicrevert)
         (rewind)(fixcycstat)

--- a/src/proposals/proposal_campaign_funding.cpp
+++ b/src/proposals/proposal_campaign_funding.cpp
@@ -3,6 +3,8 @@
 
 void ProposalCampaignFunding::create_impl (std::map<std::string, VariantValue> & args) {
 
+  check(false, "Funding campaigns are disabled.")
+
   dao::proposal_auxiliary_tables propaux_t(contract_name, contract_name.value);
 
   asset quantity = std::get<asset>(args["quantity"]);

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -2397,6 +2397,62 @@ ACTION proposals::testalliance (uint64_t id, name creator, asset quantity, asset
 
 }
 
+ACTION proposals::migcampaign ( uint64_t start, uint64_t chunksize ) {
+
+  require_auth(get_self());
+
+  auto props_by_campaign_type_id = props.get_index<"bycmptypeid"_n>();
+
+  uint128_t id = (uint128_t(campaign_funding_type.value) << 64);
+  auto pitr = props_by_campaign_type_id.lower_bound(id);
+
+  uint64_t count = 0;
+
+  while (pitr != props_by_campaign_type_id.end() && count < chunksize) {
+
+    if (pitr->campaign_type == campaign_funding_type) {
+
+      // Cancel existing ongoing funding campaigns and return the stake to the creator
+      // Cancel staged funding campaigns and return the stake
+
+      if ( pitr->stage == stage_active || pitr->stage == stage_staged ) {
+
+        refund_staked(pitr->creator, pitr->staked );
+
+        props_by_campaign_type_id.modify(pitr, _self, [&](auto & prop){
+          prop.staked = asset(0, utils::seeds_symbol);
+          prop.status = status_inactive;
+          prop.stage = stage_done;
+        });
+
+      }
+
+
+    }
+
+    pitr++;
+    count++;
+  }
+
+  if (pitr != props_by_campaign_type_id.end() && pitr->campaign_type == campaign_funding_type) {
+
+    action next_execution(
+      permission_level{get_self(), "active"_n},
+      get_self(),
+      "migcampaign"_n,
+      std::make_tuple(pitr->id, chunksize)
+    );
+
+    transaction tx;
+    tx.actions.emplace_back(next_execution);
+    tx.delay_sec = 1;
+    tx.send(pitr->id, _self);
+
+  }
+
+
+}
+
 // TODO: Remove
 ACTION proposals::migalliances (uint64_t start, uint64_t chunksize) {
 

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -3379,3 +3379,116 @@ describe('Cycle stats use moon cycle phases as start and end times', async asser
 
 })
 
+
+/* just to test the migration works as intented
+describe('migration', async assert => {
+
+  if (!isLocal()) {
+    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+    return
+  }
+
+  const contracts = await initContracts({ accounts, proposals, token, harvest, settings, escrow })
+
+  console.log('settings reset')
+  await contracts.settings.reset({ authorization: `${settings}@active` })
+
+  console.log('set propmajority to 80')
+  await contracts.settings.configure('propmajority', 80, { authorization: `${settings}@active` })
+
+  console.log('token reset')
+  await contracts.token.resetweekly({ authorization: `${token}@active` })
+
+  console.log('accounts reset')
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+
+  console.log('harvest reset')
+  await contracts.harvest.reset({ authorization: `${harvest}@active` })
+
+  console.log('proposals reset')
+  await contracts.proposals.reset({ authorization: `${proposals}@active` })
+
+  console.log('escrow reset')
+  await contracts.escrow.reset({ authorization: `${escrow}@active` })
+
+  console.log('join users')
+  await contracts.accounts.adduser(firstuser, 'firstuser', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.adduser(seconduser, 'seconduser', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.adduser(thirduser, 'thirduser', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.adduser(fourthuser, 'fourthuser', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.testcitizen(firstuser, { authorization: `${accounts}@active` })
+  await contracts.accounts.testresident(seconduser, { authorization: `${accounts}@active` })
+  await contracts.accounts.testresident(thirduser, { authorization: `${accounts}@active` })
+  await contracts.accounts.testresident(fourthuser, { authorization: `${accounts}@active` })
+
+  console.log('create proposal '+campaignbank)
+  await contracts.proposals.createx(firstuser, firstuser, '1000.0000 SEEDS', '1000 seeds please', 'summary', 'description', 'image', 'url', campaignbank, [ 10, 30, 30, 30 ], { authorization: `${firstuser}@active` })
+  await contracts.proposals.createx(seconduser, seconduser, '100000.0000 SEEDS', '100,0000 seeds please', 'summary', 'description', 'image', 'url', campaignbank, [ 10, 30, 30, 30 ], { authorization: `${seconduser}@active` })
+  await contracts.proposals.createx(thirduser, thirduser, '10000000.0000 SEEDS', '1,000,000 seeds please', 'summary', 'description', 'image', 'url', campaignbank, [ 10, 30, 30, 30 ], { authorization: `${thirduser}@active` })
+
+  console.log('stake the minimum')
+  await contracts.token.transfer(firstuser, proposals, '554.0000 SEEDS', '', { authorization: `${firstuser}@active` })
+  
+  let expectNotEnough = true
+  try {
+    await contracts.proposals.checkstake(1, { authorization: `${firstuser}@active` })
+    expectNotEnough = false
+  } catch (err) {
+
+  }
+  await contracts.token.transfer(firstuser, proposals, '1.0000 SEEDS', '', { authorization: `${firstuser}@active` })
+  await contracts.proposals.checkstake(1, { authorization: `${firstuser}@active` })
+
+  console.log('stake 5% = 5000')
+  await contracts.token.transfer(seconduser, proposals, '555.0000 SEEDS', '', { authorization: `${seconduser}@active` })
+  let expectNotEnough2 = true
+  try {
+    await contracts.proposals.checkstake(2, { authorization: `${firstuser}@active` })
+    expectNotEnough2 = false
+  } catch (error) {
+    //console.log("expected: "+error)
+  }
+  await contracts.token.transfer(seconduser, proposals, (5000-555) + '.0000 SEEDS', '', { authorization: `${seconduser}@active` })
+  await contracts.proposals.checkstake(2, { authorization: `${firstuser}@active` })
+
+  console.log('stake max - not more than 75,000 needed')
+  await contracts.token.transfer(thirduser, proposals, '75000.0000 SEEDS', '', { authorization: `${thirduser}@active` })
+  await contracts.proposals.checkstake(3, { authorization: `${firstuser}@active` })
+
+
+  await contracts.proposals.onperiod( { authorization: `${proposals}@active` } )
+  await sleep(2000)
+
+  const props = await eos.getTableRows({
+    code: proposals,
+    scope: proposals,
+    table: 'props',
+    json: true,
+  })
+
+
+  // console.log(props)
+
+
+  console.log('************************ migrationnnnn')
+
+  await contracts.proposals.migcampaign(0, 10, { authorization: `${proposals}@active` })
+
+  await sleep(2000)
+
+
+  const mig = await eos.getTableRows({
+    code: proposals,
+    scope: proposals,
+    table: 'props',
+    json: true,
+  })
+
+
+  console.log(mig)
+
+
+
+
+})
+*/


### PR DESCRIPTION
Fix #423 

This PR includes changes as follows:

Create a new action that: 
- Returns stake of ongoing and staged funding campaigns.
- Cancels ongoing and staged funding campaigns.

